### PR TITLE
added "interface ignore wildcard" when ntp_config_listen is set

### DIFF
--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -18,6 +18,9 @@ statistics {{ ntp_config_statistics }}
 filegen {{ filegen }}
 {% endfor %}
 
+{% if ntp_config_listen %}
+interface ignore wildcard
+{% endif %}
 {% for listen in ntp_config_listen %}
 interface listen {{ listen }}
 {% endfor %}


### PR DESCRIPTION
if someone is setting a specific listen address then we probably don't want to listen on 0.0.0.0